### PR TITLE
#11 | StringValueObject::assert argument should be named $value to be consistent

### DIFF
--- a/src/Abstracts/StringValueObject.php
+++ b/src/Abstracts/StringValueObject.php
@@ -42,5 +42,5 @@ abstract class StringValueObject implements StringValueObjectInterface
     /**
      * @throws \Throwable When the string value does not match the requirements
      */
-    abstract protected function assert(string $string): void;
+    abstract protected function assert(string $value): void;
 }

--- a/src/Email/Email.php
+++ b/src/Email/Email.php
@@ -17,9 +17,9 @@ class Email extends StringValueObject
         return explode('@', $this->toString())[1];
     }
 
-    protected function assert(string $string): void
+    protected function assert(string $value): void
     {
-        Assertion::email($string);
+        Assertion::email($value);
     }
 
     protected function modifyValue(string $value): string

--- a/tests/Dummies/NotEmptyString.php
+++ b/tests/Dummies/NotEmptyString.php
@@ -7,9 +7,9 @@ use InvalidArgumentException;
 
 final class NotEmptyString extends StringValueObject
 {
-    protected function assert(string $string): void
+    protected function assert(string $value): void
     {
-        if (!empty($string)) {
+        if (!empty($value)) {
             return;
         }
 


### PR DESCRIPTION
Solves #11 